### PR TITLE
go1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - '1.23'
         - '1.24'
+        - '1.25'
 
     steps:
       - uses: actions/checkout@v4

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -69,7 +69,7 @@ func setup(tb testing.TB) {
 
 func compile(tb testing.TB) {
 	tb.Helper()
-	err := exec.Command("go", "build", "-o", "echod").Run()
+	err := exec.Command("go", "build", "-o", "tcp-echod").Run()
 	if err != nil {
 		tb.Fatal("failed to build echod")
 	}
@@ -80,7 +80,7 @@ func compile(tb testing.TB) {
 
 func runServer(tb testing.TB) {
 	tb.Helper()
-	cmd := exec.Command("./echod", "127.0.0.1:2929")
+	cmd := exec.Command("./tcp-echod", "127.0.0.1:2929")
 	if err := cmd.Start(); err != nil {
 		tb.Fatal("cannot start echod:", err)
 	}

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestEcho(t *testing.T) {
-	t.SkipNow()
 	setup(t)
 
 	t.Run("should be connectable via tcp4", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kurth4cker/tcp-echod
 
-go 1.23.6
+go 1.24.0


### PR DESCRIPTION
- **Revert "main: tests, skip for now"**
- **all: build as tcp-echod**
- **all: drop go1.23 support**
